### PR TITLE
Fix Docker build paths for entrypoint and configs

### DIFF
--- a/revcopy-admin-main/nginx/admin.conf
+++ b/revcopy-admin-main/nginx/admin.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    location /health {
+        return 200 'OK';
+        add_header Content-Type text/plain;
+    }
+}

--- a/revcopy-admin-main/nginx/nginx-admin.conf
+++ b/revcopy-admin-main/nginx/nginx-admin.conf
@@ -1,0 +1,18 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/revcopy-backend-main/scripts/backend-entrypoint.sh
+++ b/revcopy-backend-main/scripts/backend-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Backend entrypoint script for RevCopy production deployment
+
+set -e
+
+# Wait for database to be ready
+echo "Waiting for database to be ready..."
+while ! nc -z postgres 5432; do
+  echo "Waiting for PostgreSQL..."
+  sleep 2
+done
+echo "PostgreSQL is ready!"
+
+# Wait for Redis to be ready
+echo "Waiting for Redis to be ready..."
+while ! nc -z redis 6379; do
+  echo "Waiting for Redis..."
+  sleep 1
+done
+echo "Redis is ready!"
+
+# Run database migrations
+echo "Running database migrations..."
+python -m alembic upgrade head || echo "Migration failed or no migrations to run"
+
+# Start the application
+echo "Starting FastAPI application..."
+exec "$@" 

--- a/revcopy-frontend-main/nginx/frontend.conf
+++ b/revcopy-frontend-main/nginx/frontend.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    location /health {
+        return 200 'OK';
+        add_header Content-Type text/plain;
+    }
+}

--- a/revcopy-frontend-main/nginx/nginx-frontend.conf
+++ b/revcopy-frontend-main/nginx/nginx-frontend.conf
@@ -1,0 +1,18 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/revcopy-server-main/dockerfiles/Dockerfile.admin
+++ b/revcopy-server-main/dockerfiles/Dockerfile.admin
@@ -57,10 +57,10 @@ RUN if ! id -u nginx >/dev/null 2>&1; then \
 COPY --from=build /app/dist /usr/share/nginx/html
 
 # Copy custom Nginx configuration for admin panel
-COPY revcopy-server-main/configs/nginx/admin.conf /etc/nginx/conf.d/default.conf
+COPY nginx/admin.conf /etc/nginx/conf.d/default.conf
 
 # Copy Nginx main configuration
-COPY revcopy-server-main/configs/nginx/nginx-admin.conf /etc/nginx/nginx.conf
+COPY nginx/nginx-admin.conf /etc/nginx/nginx.conf
 
 # Create necessary directories and set permissions
 RUN mkdir -p /var/cache/nginx /var/log/nginx /var/run && \

--- a/revcopy-server-main/dockerfiles/Dockerfile.backend
+++ b/revcopy-server-main/dockerfiles/Dockerfile.backend
@@ -103,7 +103,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy entrypoint script
-COPY revcopy-server-main/scripts/backend-entrypoint.sh /entrypoint.sh
+COPY scripts/backend-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && \
     chown appuser:appuser /entrypoint.sh
 

--- a/revcopy-server-main/dockerfiles/Dockerfile.frontend
+++ b/revcopy-server-main/dockerfiles/Dockerfile.frontend
@@ -57,10 +57,10 @@ RUN if ! id -u nginx >/dev/null 2>&1; then \
 COPY --from=build /app/dist /usr/share/nginx/html
 
 # Copy custom Nginx configuration
-COPY revcopy-server-main/configs/nginx/frontend.conf /etc/nginx/conf.d/default.conf
+COPY nginx/frontend.conf /etc/nginx/conf.d/default.conf
 
 # Copy Nginx main configuration
-COPY revcopy-server-main/configs/nginx/nginx-frontend.conf /etc/nginx/nginx.conf
+COPY nginx/nginx-frontend.conf /etc/nginx/nginx.conf
 
 # Create necessary directories and set permissions
 RUN mkdir -p /var/cache/nginx /var/log/nginx /var/run && \


### PR DESCRIPTION
## Summary
- add required frontend/admin nginx configurations
- include backend entrypoint script in build context
- update Dockerfiles to reference new local paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686ea6c29d30832dad08efe26ad1dd90