### PR TITLE
Fix frontend and admin build steps

### DIFF
--- a/revcopy-server-main/dockerfiles/Dockerfile.admin
+++ b/revcopy-server-main/dockerfiles/Dockerfile.admin
@@ -21,8 +21,8 @@ ENV NODE_ENV=production \
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies with clean cache
-RUN npm ci --only=production --no-audit --prefer-offline && \
+# Install dependencies with dev packages for build
+RUN npm ci --no-audit --prefer-offline && \
     npm cache clean --force
 
 # Copy source code

--- a/revcopy-server-main/dockerfiles/Dockerfile.frontend
+++ b/revcopy-server-main/dockerfiles/Dockerfile.frontend
@@ -21,8 +21,8 @@ ENV NODE_ENV=production \
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies with clean cache
-RUN npm ci --only=production --no-audit --prefer-offline && \
+# Install dependencies with dev packages for build
+RUN npm ci --no-audit --prefer-offline && \
     npm cache clean --force
 
 # Copy source code


### PR DESCRIPTION
## Summary
- install dev dependencies when building frontend and admin images so Vite is present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails due to network access restriction)*

------
https://chatgpt.com/codex/tasks/task_e_686eaa34dc90832d88068473e489f6ad